### PR TITLE
User test feedback fixes

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -10,7 +10,11 @@ chrome.contextMenus.onClicked.addListener((itemData) => {
         code: 'window.getSelection().toString();',
       },
       (selection) => {
-        sendMessage({ dataUrl: `data:text/plain,${selection[0]}` })
+        sendMessage({
+          src: window.location.href,
+          capturedAt: Date.now(),
+          dataUrl: `data:text/plain,${selection[0]}`,
+        })
       }
     )
   }
@@ -34,7 +38,11 @@ chrome.contextMenus.onClicked.addListener((itemData) => {
       }
       context.drawImage(tmpImage, 0, 0)
 
-      sendMessage({ dataUrl: canvas.toDataURL() })
+      sendMessage({
+        src: itemData.srcUrl,
+        capturedAt: Date.now(),
+        dataUrl: canvas.toDataURL(),
+      })
     }
   }
 })
@@ -76,7 +84,7 @@ function startActionFeedback() {
     feedbackTimerGlobal = null
     updateBadge('', '#00000000')
     chrome.browserAction.enable()
-  }, 2000)
+  }, 20000)
 }
 
 function triggerActionFeedback(text, color) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -49,18 +49,34 @@ chrome.runtime.onInstalled.addListener(() => {
 
 chrome.browserAction.onClicked.addListener((tab) => {
   startActionFeedback()
-  chrome.tabs.executeScript({
-    file: 'content.js',
-  })
+  chrome.tabs.executeScript(
+    {
+      file: 'content.js',
+    },
+    () => {
+      let e = chrome.runtime.lastError
+      if (e !== undefined) {
+        console.log('error during executeScript')
+        triggerActionFeedback('❌', '')
+      }
+    }
+  )
 })
 
 function updateBadge(text, color) {
   chrome.browserAction.setBadgeText({ text })
-  chrome.browserAction.setBadgeBackgroundColor({ color })
+  chrome.browserAction.setBadgeBackgroundColor({ color: [255, 255, 255, 0] })
 }
 
 function startActionFeedback() {
-  triggerActionFeedback('', 'green')
+  updateBadge('🔄', '#00000000')
+  chrome.browserAction.disable()
+
+  feedbackTimerGlobal = setTimeout(() => {
+    feedbackTimerGlobal = null
+    updateBadge('', '#00000000')
+    chrome.browserAction.enable()
+  }, 2000)
 }
 
 function triggerActionFeedback(text, color) {
@@ -71,25 +87,26 @@ function triggerActionFeedback(text, color) {
   feedbackTimerGlobal = setTimeout(() => {
     feedbackTimerGlobal = null
     updateBadge('', color)
-  }, 1000)
+    chrome.browserAction.enable()
+  }, 2000)
 }
 
 function clipperResponse(response) {
   switch (response.type) {
     case 'Ack':
-      triggerActionFeedback('OK', 'green')
+      triggerActionFeedback('✔️', '')
       break
     case 'Failed':
       console.log(response)
-      triggerActionFeedback('NO', 'red')
+      triggerActionFeedback('❌', '')
       break
     default:
       console.log(response)
-      triggerActionFeedback('?', 'yellow')
+      triggerActionFeedback('❓', '')
   }
 }
 
-chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   // For now, all messages go to the native host. We might want to filter here
   // in the future.
   sendMessage(request, clipperResponse)

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,6 +1,19 @@
 import freezeDry from 'freeze-dry'
 
-freezeDry(document, { addMetadata: true }).then((html) => {
-  const msg = { src: window.location.href, dataUrl: `data:text/html,${encodeURIComponent(html)}` }
+if (document.querySelector('embed[type="application/pdf"]')) {
+  const msg = {
+    src: window.location.href,
+    dataUrl: `data:text/plain,${window.location.href}`,
+    capturedAt: Date.now(),
+  }
   chrome.runtime.sendMessage(msg)
-})
+} else {
+  freezeDry(document, { addMetadata: true }).then((html) => {
+    const msg = {
+      src: window.location.href,
+      dataUrl: `data:text/html,${encodeURIComponent(html)}`,
+      capturedAt: Date.now(),
+    }
+    chrome.runtime.sendMessage(msg)
+  })
+}


### PR DESCRIPTION
Some stuff:
 - a circle-arrow unicode character appears immediately when you click
 - the button disables when you click
 - success is now a check / failure is an X / anything else is a ?
 - after 20s we clear the icon & reenable the clipper
 - pdfs are sent over as text/plain of their URL which works... ish.
 - all clips now have a src and a capturedAt
 - badge color is kinda not doing anything good right now (styling ideas welcome)
 - exceptions from executeScript are now caught, logged, and give good feedback

Some not-done stuff:
 - pushpin 16x16 logo
 - remove color code (waiting for your input on the patch before doing that)
 - figuring out how to get the downloaded PDF data from chrome without a refetch (this is very non-obvious)
